### PR TITLE
Set bash prompt to parent/current git(git-branch)

### DIFF
--- a/src/psh.sh
+++ b/src/psh.sh
@@ -196,6 +196,9 @@ _ensure_rcfile
 # shellcheck disable=SC1091
 source pshrc
 
+#Bash Prompt
+export PS1='${PWD#"${PWD%/*/*}/"} git:($(git rev-parse --abbrev-ref HEAD)) \$ '
+
 # PHP before composer
 if [ -n "${larg_php}" ]; then
   php=$larg_php

--- a/src/psh.sh
+++ b/src/psh.sh
@@ -23,7 +23,6 @@ function composer_alias() {
   hash -r
   # shellcheck disable=SC2139
   alias composer="php $selected"
-  alias >>"$tempfile"
 }
 
 function composer_all() {
@@ -52,7 +51,6 @@ function node_alias() {
   hash -r
   # shellcheck disable=SC2139
   alias node="$selected"
-  alias >>"$tempfile"
 }
 
 function node_all() {
@@ -103,7 +101,6 @@ function php_alias() {
 
   # refresh shell
   hash -r
-  alias >>"$tempfile"
 }
 
 function php_all() {
@@ -221,4 +218,5 @@ if [ -n "${node-}" ]; then
   node_alias "$node"
 fi
 
+alias >>"$tempfile"
 bash --rcfile "$tempfile"


### PR DESCRIPTION
Fix #13 

```
➜ z psh
Using PHP     : /usr/local/Cellar/php@7.3/7.3.29
shell/psh git:(bash-prompt) $ cat pshrc
php=7.3
shell/psh git:(bash-prompt) $
```